### PR TITLE
Add add_peer function

### DIFF
--- a/lib/wireguardex.ex
+++ b/lib/wireguardex.ex
@@ -54,6 +54,14 @@ defmodule WireguardEx do
   def remove_peer(_name, _public_key), do: error()
 
   @doc """
+  Add a peer to a `Device`.
+
+  Returns `:ok` if successful. `{:error, error_info}` will be returned if adding
+  the peer to the device fails.
+  """
+  def add_peer(_name, _peer), do: error()
+
+  @doc """
   Generates a random private key. It is returned as a base64 string.
   """
   def generate_private_key(), do: error()

--- a/native/wireguard_nif/src/key.rs
+++ b/native/wireguard_nif/src/key.rs
@@ -1,7 +1,9 @@
 //! nif bindings for generating wireguard keys
 
-use rustler::{Error, NifResult};
+use rustler::NifResult;
 use wireguard_control::Key;
+
+use crate::device::to_term_error;
 
 #[rustler::nif]
 fn generate_private_key() -> String {
@@ -25,5 +27,5 @@ fn get_public_key(key: &str) -> NifResult<String> {
 }
 
 pub(crate) fn from_base64(key: &str) -> NifResult<Key> {
-    Key::from_base64(key).map_err(|e| Error::Term(Box::new(e.to_string())))
+    to_term_error(Key::from_base64(key))
 }

--- a/native/wireguard_nif/src/lib.rs
+++ b/native/wireguard_nif/src/lib.rs
@@ -4,7 +4,7 @@ mod device;
 mod key;
 mod peer;
 
-use device::{delete_device, get_device, list_devices, remove_peer, set_device};
+use device::{delete_device, get_device, list_devices, remove_peer, set_device, add_peer};
 use key::{generate_preshared_key, generate_private_key, get_public_key};
 
 rustler::init!(
@@ -18,5 +18,6 @@ rustler::init!(
         generate_private_key,
         generate_preshared_key,
         get_public_key,
+        add_peer,
     ]
 );

--- a/native/wireguard_nif/src/peer.rs
+++ b/native/wireguard_nif/src/peer.rs
@@ -1,13 +1,12 @@
 //! nif bindings for wireguard peers
 
 use std::convert::TryFrom;
-use std::net::AddrParseError;
 use std::time::SystemTime;
 
 use rustler::{Error, NifResult, NifStruct};
 use wireguard_control::{AllowedIp, PeerConfig, PeerConfigBuilder, PeerInfo, PeerStats};
 
-use crate::key;
+use crate::{device::to_term_error, key};
 
 #[derive(NifStruct)]
 #[module = "WireguardEx.PeerConfig"]
@@ -59,11 +58,7 @@ impl TryFrom<NifPeerConfig> for PeerConfigBuilder {
             config = config.set_preshared_key(key::from_base64(&preshared_key)?);
         }
         if let Some(endpoint) = endpoint {
-            config = config.set_endpoint(
-                endpoint
-                    .parse()
-                    .map_err(|e: AddrParseError| Error::Term(Box::new(e.to_string())))?,
-            );
+            config = config.set_endpoint(to_term_error(endpoint.parse())?);
         }
         if let Some(persistent_keepalive_interval) = persistent_keepalive_interval {
             config = config.set_persistent_keepalive_interval(persistent_keepalive_interval);

--- a/test/wireguardex_test.exs
+++ b/test/wireguardex_test.exs
@@ -70,4 +70,27 @@ defmodule WireguardExTest do
     assert List.first(device.peers).config == List.first(peers)
     assert List.last(device.peers).config == List.last(peers)
   end
+
+  test "add peer to device after creation" do
+    interface_name = "wg3"
+
+    peer = %WireguardEx.PeerConfig{
+      public_key: WireguardEx.get_public_key(WireguardEx.generate_private_key()),
+      preshared_key: WireguardEx.generate_preshared_key(),
+      endpoint: "127.0.0.1:1234",
+      persistent_keepalive_interval: 60,
+      allowed_ips: ["192.168.0.0/24", "163.23.42.242/32"]
+    }
+
+    set_result = WireguardEx.set_device(interface_name, %WireguardEx.DeviceConfig{})
+
+    add_result = WireguardEx.add_peer(interface_name, peer)
+    device = WireguardEx.get_device(interface_name)
+    delete_result = WireguardEx.delete_device(interface_name)
+
+    assert set_result == :ok
+    assert add_result == :ok
+    assert List.first(device.peers).config == peer
+    assert delete_result == :ok
+  end
 end


### PR DESCRIPTION
I added the `add_peer` function and also added a new small `to_term_error` function to reduce some code duplication when mapping error to the nif error.