### PR TITLE
Adds builder pattern in elixir for both DeviceConfig and PeerConfig

### DIFF
--- a/lib/wireguardex.ex
+++ b/lib/wireguardex.ex
@@ -47,7 +47,7 @@ defmodule Wireguardex do
   Returns `:ok` if successful. `{:error, error_info}` will be returned if setting
   the device fails.
   """
-  def set_device(_name, _device_config), do: error()
+  def set_device(_device_config, _name), do: error()
 
   @doc """
   Delete a `Device` by its interface name.

--- a/lib/wireguardex/device_config.ex
+++ b/lib/wireguardex/device_config.ex
@@ -1,20 +1,5 @@
 defmodule Wireguardex.DeviceConfig do
-  @moduledoc """
-  `DeviceConfig` represents a configuration that can be set on a Wireguard
-  device (interface).
-
-  If an interface exists, the configuration is applied _on top_ of the existing
-  interface's settings. Missing settings are not overwritten or set to defaults.
-
-  * `public_key` The public encryption key to set on the interface.
-  * `private_key` The private encryption key to set on the interface.
-  * `fwmark` The [fwmark](https://man7.org/linux/man-pages/man8/tc-fw.8.html) to
-    set on the interface.
-  * `listen_port` The listening port for incoming connections to set on the interface.
-  * `peers` A list of peers with their own configurations to set on this interface.
-  * `replace_peers` If true, replace existing peer configurations on the interface.
-    If false, modify existing peer configurations or append them to the interface.
-  """
+  @moduledoc false
   defstruct public_key: nil,
             private_key: nil,
             fwmark: nil,

--- a/lib/wireguardex/device_config_builder.ex
+++ b/lib/wireguardex/device_config_builder.ex
@@ -1,0 +1,73 @@
+defmodule Wireguardex.DeviceConfigBuilder do
+  @moduledoc ~S"""
+  This module contains functions to create a `DeviceConfig` which itself
+  represents a configuration that can be set on a Wireguard device (interface).
+
+  If an interface exists, the configuration is applied _on top_ of the existing
+  interface's settings. Missing settings are not overwritten or set to defaults.
+
+  To crate the default config use `device_config/0` then you can apply each
+  function in this module to specify the details.
+
+  ## Examples
+
+      iex> res=
+      ...> device_config()
+      ...> |> listen_port(1234)
+      ...> |> fwmark(11111)
+      ...> |> Wireguardex.set_device("wg1234")
+      ...> Wireguardex.delete_device("wg1234")
+      ...> res
+      :ok
+  """
+
+  @doc """
+  The public encryption key to set on the interface.
+  """
+  def public_key(config_builder, public_key) do
+    %{config_builder | public_key: public_key}
+  end
+
+  @doc """
+  The private encryption key to set on the interface.
+  """
+  def private_key(config_builder, private_key) do
+    %{config_builder | private_key: private_key}
+  end
+
+  @doc """
+  The [fwmark](https://man7.org/linux/man-pages/man8/tc-fw.8.html) to set on the
+  interface.
+  """
+  def fwmark(config_builder, fwmark) do
+    %{config_builder | fwmark: fwmark}
+  end
+
+  @doc """
+  The listening port for incoming connections to set on the interface.
+  """
+  def listen_port(config_builder, listen_port) do
+    %{config_builder | listen_port: listen_port}
+  end
+
+  @doc """
+  A list of peers with their own configurations to set on this interface.
+  """
+  def peers(config_builder, peers) do
+    %{config_builder | peers: peers}
+  end
+
+  @doc """
+  If true, replace existing peer configurations on the interface.
+  """
+  def replace_peers(config_builder, replace_peers) do
+    %{config_builder | replace_peers: replace_peers}
+  end
+
+  @doc """
+  Creates the default configuration to be then configured with the provided functions.
+  """
+  def device_config() do
+    %Wireguardex.DeviceConfig{}
+  end
+end

--- a/lib/wireguardex/peer_config.ex
+++ b/lib/wireguardex/peer_config.ex
@@ -1,16 +1,5 @@
 defmodule Wireguardex.PeerConfig do
-  @moduledoc """
-  `PeerConfig` represents a peer's configuration of persistent attributes. They do
-  not change over time and are part of the configuration of a device.
-
-  * `public_key` The public key of the peer.
-  * `preshared_key` The preshared key available to both peers (`nil` means no PSK
-    is used).
-  * `endpoint` The endpoint this peer listens for connections on (`nil` means any).
-  * `persistent_keepalive_interval` The interval for sending keepalive packets
-    (`nil` means disabled).
-  * `allowed_ips` The allowed ip addresses this peer is allowed to have.
-  """
+  @moduledoc false
   defstruct public_key: "",
             preshared_key: nil,
             endpoint: nil,

--- a/lib/wireguardex/peer_config_builder.ex
+++ b/lib/wireguardex/peer_config_builder.ex
@@ -1,0 +1,70 @@
+defmodule Wireguardex.PeerConfigBuilder do
+  @moduledoc ~S"""
+  This module contains functions to create a `PeerConfig`  which represents
+  a peer's configuration of persistent attributes. They do not change over
+  time and are part of the configuration of a device.
+
+  To create the defualt config use `peer_config/0` then you can apply each
+  function in this module to specify the config.
+
+  ## Examples
+
+      iex> res =
+      ...> device_config()
+      ...> |> peers([
+      ...>      peer_config()
+      ...>      |> Wireguardex.PeerConfigBuilder.public_key(Wireguardex.get_public_key(Wireguardex.generate_private_key()))
+      ...>      |> endpoint("127.0.0.1:1234")
+      ...>      |> preshared_key(Wireguardex.generate_preshared_key())
+      ...>      |> persistent_keepalive_interval(60)
+      ...>      |> allowed_ips(["127.0.0.1/16"])
+      ...> ])
+      ...> |> Wireguardex.set_device("wg12345")
+      ...> Wireguardex.delete_device("wg12345")
+      ...> res
+      :ok
+  """
+
+  @doc """
+  Creates the default peer configuration that you can then specify which each of
+  the provided functions.
+  """
+  def peer_config() do
+    %Wireguardex.PeerConfig{}
+  end
+
+  @doc """
+  The public key of the peer.
+  """
+  def public_key(peer_config, public_key) do
+    %{peer_config | public_key: public_key}
+  end
+
+  @doc """
+  The preshared key available to both peers (`nil` means no PSK is used).
+  """
+  def preshared_key(peer_config, preshared_key) do
+    %{peer_config | preshared_key: preshared_key}
+  end
+
+  @doc """
+  The endpoint this peer listens for connections on (`nil` means any).
+  """
+  def endpoint(peer_config, endpoint) do
+    %{peer_config | endpoint: endpoint}
+  end
+
+  @doc """
+  The interval for sending keepalive packets (`nil` means disabled).
+  """
+  def persistent_keepalive_interval(peer_config, persistent_keepalive_interval) do
+    %{peer_config | persistent_keepalive_interval: persistent_keepalive_interval}
+  end
+
+  @doc """
+  The allowed ip addresses this peer is allowed to have.
+  """
+  def allowed_ips(peer_config, allowed_ips) do
+    %{peer_config | allowed_ips: allowed_ips}
+  end
+end

--- a/native/wireguard_nif/src/device.rs
+++ b/native/wireguard_nif/src/device.rs
@@ -102,7 +102,7 @@ fn get_device(name: &str) -> NifResult<NifDevice> {
 }
 
 #[rustler::nif]
-fn set_device(name: &str, config: NifDeviceConfig) -> NifResult<Atom> {
+fn set_device(config: NifDeviceConfig, name: &str) -> NifResult<Atom> {
     let iname = parse_iname(name)?;
     let device: DeviceUpdate = config.try_into()?;
 


### PR DESCRIPTION
This is the idea I have to use the builder pattern, I thought it would be easier to make it in Elixir, the bad part is that in this way we can't hide AFAIK the `DeviceConfig` and `PeerConfig` structs, there are no private structs I think.

Maybe we can mangle the names somehow but I'm not sure that's the best approach.

Let me know what you think.