### PR TITLE
Wrap list_devices & get_device results with ok atoms

### DIFF
--- a/lib/wireguardex.ex
+++ b/lib/wireguardex.ex
@@ -26,7 +26,7 @@ defmodule Wireguardex do
   @doc """
   Get a list of interfaces from wireguard.
 
-  Returns `[...]` if successful. `{:error, error_info}` will be returned
+  Returns `{:ok, [...]}` if successful. `{:error, error_info}` will be returned
   if listing the devices fails.
   """
   def list_devices, do: error()
@@ -34,7 +34,7 @@ defmodule Wireguardex do
   @doc """
   Get a `Device` by its interface name.
 
-  Returns `Device` if successful. `{:error, error_info}` will be returned
+  Returns `{:ok, Device}` if successful. `{:error, error_info}` will be returned
   if getting the device fails.
   """
   def get_device(_name), do: error()

--- a/native/wireguard_nif/src/device.rs
+++ b/native/wireguard_nif/src/device.rs
@@ -86,19 +86,19 @@ struct NifDeviceConfig {
 }
 
 #[rustler::nif]
-fn list_devices() -> NifResult<Vec<String>> {
-    Ok(to_term_error(Device::list(BACKEND))?
+fn list_devices() -> NifResult<(Atom, Vec<String>)> {
+    Ok((atom::ok(), to_term_error(Device::list(BACKEND))?
         .iter()
         .map(|iname| iname.as_str_lossy().to_string())
-        .collect())
+        .collect()))
 }
 
 #[rustler::nif]
-fn get_device(name: &str) -> NifResult<NifDevice> {
+fn get_device(name: &str) -> NifResult<(Atom, NifDevice)> {
     let iname = parse_iname(name)?;
     let device = to_term_error(Device::get(&iname, BACKEND))?;
 
-    Ok(device.into())
+    Ok((atom::ok(), device.into()))
 }
 
 #[rustler::nif]

--- a/test/wireguardex_test.exs
+++ b/test/wireguardex_test.exs
@@ -14,7 +14,7 @@ defmodule WireguardexTest do
     listen_port = 58210
     fwmark = 1234
 
-    set_result =
+    :ok =
       device_config()
       |> private_key(private_key)
       |> Wireguardex.PeerConfigBuilder.public_key(public_key)
@@ -22,11 +22,9 @@ defmodule WireguardexTest do
       |> fwmark(fwmark)
       |> set_device(interface_name)
 
-    device = Wireguardex.get_device(interface_name)
-    delete_result = Wireguardex.delete_device(interface_name)
+    {:ok, device} = Wireguardex.get_device(interface_name)
+    :ok = Wireguardex.delete_device(interface_name)
 
-    assert set_result == :ok
-    assert delete_result == :ok
     assert device.name == interface_name
     assert device.public_key == public_key
     assert device.private_key == private_key
@@ -36,12 +34,10 @@ defmodule WireguardexTest do
 
   test "list devices" do
     interface_name = "wg1"
-    set_result = Wireguardex.set_device(%Wireguardex.DeviceConfig{}, interface_name)
-    devices = Wireguardex.list_devices()
-    delete_result = Wireguardex.delete_device(interface_name)
+    :ok = Wireguardex.set_device(%Wireguardex.DeviceConfig{}, interface_name)
+    {:ok, devices} = Wireguardex.list_devices()
+    :ok = Wireguardex.delete_device(interface_name)
 
-    assert set_result == :ok
-    assert delete_result == :ok
     assert List.first(devices) == interface_name
   end
 
@@ -67,16 +63,14 @@ defmodule WireguardexTest do
       |> allowed_ips(["255.0.0.0/24", "127.0.0.0/16"])
     ]
 
-    set_result =
+    :ok =
       device_config()
       |> peers(peers)
       |> set_device(interface_name)
 
-    device = Wireguardex.get_device(interface_name)
-    delete_result = Wireguardex.delete_device(interface_name)
+    {:ok, device} = Wireguardex.get_device(interface_name)
+    :ok = Wireguardex.delete_device(interface_name)
 
-    assert set_result == :ok
-    assert delete_result == :ok
     assert List.first(device.peers).config == List.first(peers)
     assert List.last(device.peers).config == List.last(peers)
   end
@@ -92,17 +86,14 @@ defmodule WireguardexTest do
       allowed_ips: ["192.168.0.0/24", "163.23.42.242/32"]
     }
 
-    set_result =
+    :ok =
       device_config()
       |> set_device(interface_name)
 
-    add_result = Wireguardex.add_peer(interface_name, peer)
-    device = Wireguardex.get_device(interface_name)
-    delete_result = Wireguardex.delete_device(interface_name)
+    :ok = Wireguardex.add_peer(interface_name, peer)
+    {:ok, device} = Wireguardex.get_device(interface_name)
+    :ok = Wireguardex.delete_device(interface_name)
 
-    assert set_result == :ok
-    assert add_result == :ok
     assert List.first(device.peers).config == peer
-    assert delete_result == :ok
   end
 end


### PR DESCRIPTION
I just saw that I overlooked wrapping the nifs that actually return values with :ok atoms. I figured the get_public_key is changing so I didn't touch that one.

Just wanted to get this in before we rev up to 0.2.0 after the base64 key changes.