### PR TITLE
Fix typo in NifPeerInfo module attribute

### DIFF
--- a/native/wireguard_nif/src/peer.rs
+++ b/native/wireguard_nif/src/peer.rs
@@ -71,7 +71,7 @@ impl TryFrom<NifPeerConfig> for PeerConfigBuilder {
 }
 
 #[derive(NifStruct)]
-#[module = "WireguardEx.PeerInfo"]
+#[module = "Wireguardex.PeerInfo"]
 pub(crate) struct NifPeerInfo {
     config: NifPeerConfig,
     stats: NifPeerStats,


### PR DESCRIPTION
Just ran into this while using the library. The module wasn't properly namespaced.