### PR TITLE
Add config to pass RUSTLER_NIF_VERSION to Cross

### DIFF
--- a/native/wireguard_nif/Cross.toml
+++ b/native/wireguard_nif/Cross.toml
@@ -1,2 +1,7 @@
 [target.x86_64-unknown-linux-gnu]
 image = "ghcr.io/cross-rs/x86_64-unknown-linux-gnu:main-centos"
+
+[build.env]
+passthrough = [
+  "RUSTLER_NIF_VERSION"
+]


### PR DESCRIPTION
This change is necessary in order to use the correct version of NIF for
the target that is being built with `cross`.
By default, `cross` won´t  pass down the env vars from the host machine.

See https://github.com/philss/rustler_precompiled/issues/23 for further details.