### PR TITLE
Use zig for more flexible build configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,9 +153,9 @@ jobs:
             target: x86_64-unknown-linux-gnu
           - os: macos-11
             target: x86_64-unknown-linux-musl
-          - os: ubuntu-20.04
+          - os: ubuntu-18.04
             target: aarch64-apple-darwin
-          - os: ubuntu-20.04
+          - os: ubuntu-18.04
             target: x86_64-apple-darwin
 
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,7 +136,7 @@ jobs:
           - aarch64-apple-darwin
           - x86_64-apple-darwin
         os:
-          - ubuntu-20.04
+          - ubuntu-18.04
           - macos-11
         nif:
           - "2.14"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,7 +136,7 @@ jobs:
           - aarch64-apple-darwin
           - x86_64-apple-darwin
         os:
-          - ubuntu-18.04
+          - ubuntu-20.04
           - macos-11
         nif:
           - "2.14"
@@ -153,9 +153,9 @@ jobs:
             target: x86_64-unknown-linux-gnu
           - os: macos-11
             target: x86_64-unknown-linux-musl
-          - os: ubuntu-18.04
+          - os: ubuntu-20.04
             target: aarch64-apple-darwin
-          - os: ubuntu-18.04
+          - os: ubuntu-20.04
             target: x86_64-apple-darwin
 
     env:

--- a/native/wireguard_nif/Cross.toml
+++ b/native/wireguard_nif/Cross.toml
@@ -1,11 +1,6 @@
-[target.x86_64-unknown-linux-gnu]
-image = "ghcr.io/cross-rs/x86_64-unknown-linux-gnu:main-centos"
-
-[target.aarch64-unknown-linux-gnu]
-image = "ghcr.io/cross-rs/x86_64-unknown-linux-gnu:main-centos"
-pre-build = [
-  "sudo yum install -y gcc-aarch64-linux-gnu"
-]
+[build]
+# This allows us to build targets against GLIBC 2.17 from any host
+zig = "2.17"
 
 [build.env]
 passthrough = [

--- a/native/wireguard_nif/Cross.toml
+++ b/native/wireguard_nif/Cross.toml
@@ -2,8 +2,10 @@
 image = "ghcr.io/cross-rs/x86_64-unknown-linux-gnu:main-centos"
 
 [target.aarch64-unknown-linux-gnu]
-zig = true
 image = "ghcr.io/cross-rs/x86_64-unknown-linux-gnu:main-centos"
+pre-build = [
+  "sudo yum install -y gcc-aarch64-linux-gnu"
+]
 
 [build.env]
 passthrough = [

--- a/native/wireguard_nif/Cross.toml
+++ b/native/wireguard_nif/Cross.toml
@@ -2,6 +2,7 @@
 image = "ghcr.io/cross-rs/x86_64-unknown-linux-gnu:main-centos"
 
 [target.aarch64-unknown-linux-gnu]
+zig = true
 image = "ghcr.io/cross-rs/x86_64-unknown-linux-gnu:main-centos"
 
 [build.env]

--- a/native/wireguard_nif/Cross.toml
+++ b/native/wireguard_nif/Cross.toml
@@ -1,6 +1,9 @@
 [target.x86_64-unknown-linux-gnu]
 image = "ghcr.io/cross-rs/x86_64-unknown-linux-gnu:main-centos"
 
+[target.aarch64-unknown-linux-gnu]
+image = "ghcr.io/cross-rs/x86_64-unknown-linux-gnu:main-centos"
+
 [build.env]
 passthrough = [
   "RUSTLER_NIF_VERSION"


### PR DESCRIPTION
Use zig for more easily building against different targets and GLIBC versions.

