### PR TITLE
Attempt to lock Glibc to 2.17 on `gnu` targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,14 +174,9 @@ jobs:
           profile: minimal
 
       - name: Install cross
-        uses: giantswarm/install-binary-action@v1.0.0
         if: ${{ contains(matrix.os, 'ubuntu') }}
-        with:
-          binary: "cross"
-          version: "v0.2.4"
-          download_url: "https://github.com/cross-rs/cross/releases/download/${version}/cross-x86_64-unknown-linux-gnu.tar.gz"
-          tarball_binary_path: "${binary}"
-          smoke_test: "${binary} --version"
+        # Use main cross-rs to have Zig support
+        run: cargo install cross --git https://github.com/cross-rs/cross --locked
 
       - name: Extract project info
         shell: bash

--- a/native/wireguard_nif/Cross.toml
+++ b/native/wireguard_nif/Cross.toml
@@ -1,4 +1,8 @@
-[build]
+[target.x86_64-unknown-linux-gnu]
+# This allows us to build targets against GLIBC 2.17 from any host
+zig = "2.17"
+
+[target.aarch64-unknown-linux-gnu]
 # This allows us to build targets against GLIBC 2.17 from any host
 zig = "2.17"
 

--- a/native/wireguard_nif/Cross.toml
+++ b/native/wireguard_nif/Cross.toml
@@ -1,9 +1,4 @@
-[target.x86_64-unknown-linux-gnu]
-# This allows us to build targets against GLIBC 2.17 from any host
-zig = "2.17"
-
-[target.aarch64-unknown-linux-gnu]
-# This allows us to build targets against GLIBC 2.17 from any host
+[build]
 zig = "2.17"
 
 [build.env]

--- a/native/wireguard_nif/Cross.toml
+++ b/native/wireguard_nif/Cross.toml
@@ -1,4 +1,9 @@
-[build]
+[target.x86_64-unknown-linux-gnu]
+# This allows us to build targets against GLIBC 2.17 from any host
+zig = "2.17"
+
+[target.aarch64-unknown-linux-gnu]
+# This allows us to build targets against GLIBC 2.17 from any host
 zig = "2.17"
 
 [build.env]


### PR DESCRIPTION
cross-rs strikes again! Looks like all the fine and dandy `zig` builds did not build against the glibc version specified.

Trying a more specific selector.